### PR TITLE
[WIP] Add bolt task timeout parameter

### DIFF
--- a/lib/mcollective/agent/bolt_tasks.ddl
+++ b/lib/mcollective/agent/bolt_tasks.ddl
@@ -77,6 +77,13 @@ action "run_and_wait", :description => "Runs a Puppet Task that was previously d
         :default     => "{}",
         :maxlength   => 102400
 
+  input :task_timeout,
+        :prompt      => "Task Timeout",
+        :description => "The number of seconds the client should wait before returning results while tasks continue in background",
+        :type        => :integer,
+        :optional    => true,
+        :default     => nil
+
   output :task_id,
          :description => "The ID the task was created with",
          :display_as  => "Task ID",

--- a/lib/mcollective/agent/bolt_tasks.json
+++ b/lib/mcollective/agent/bolt_tasks.json
@@ -101,6 +101,13 @@
           "optional": false,
           "validation": "^.+$",
           "maxlength": 102400
+        },
+        "task_timeout": {
+          "prompt": "Task Timeout",
+          "description": "The number of seconds the client should wait before returning results while tasks continue in background",
+          "type": "integer",
+          "default": null,
+          "optional": true
         }
       },
       "output": {

--- a/lib/mcollective/agent/bolt_tasks.rb
+++ b/lib/mcollective/agent/bolt_tasks.rb
@@ -48,6 +48,10 @@ module MCollective
 
         status = nil
 
+        if request[:task_timeout]
+          timeout = request[:task_timeout]
+        end
+
         # Wait for near the timeout and on timeout give up and fetch the
         # status so users can get good replies that include how things are
         # near timeout

--- a/lib/mcollective/application/tasks.rb
+++ b/lib/mcollective/application/tasks.rb
@@ -148,6 +148,13 @@ Examples:
                           :required => false,
                           :default => 1,
                           :type => Integer
+
+        self.class.option :__task_timeout,
+                          :arguments => ["--task-timeout SECONDS"],
+                          :description => "Time to wait for all results before detaching and letting tasks continue to run in the background",
+                          :required => false,
+                          :default => nil,
+                          :type => Integer
       end
 
       def say(msg="")
@@ -181,6 +188,7 @@ Examples:
         }
 
         request[:input] = input.to_json if input
+        request[:task_timeout] = configuration[:__task_timeout] if configuration[:__task_timeout]
 
         if configuration[:__background]
           puts("Starting task %s in the background" % [Util.colorize(:bold, task)])
@@ -199,9 +207,10 @@ Examples:
             puts("Request detailed status for the task using 'mco tasks status %s'" % [Util.colorize(:bold, bolt_tasks.stats.requestid)])
           end
         else
+          task_timeout = configuration[:__task_timeout] || bolt_tasks.ddl.meta[:timeout]
           say("Running task %s and waiting up to %s seconds for it to complete" % [
             Util.colorize(:bold, task),
-            Util.colorize(:bold, bolt_tasks.ddl.meta[:timeout])
+            Util.colorize(:bold, task_timeout)
           ])
 
           request_and_report(:run_and_wait, request)


### PR DESCRIPTION
Allows the user to override the bolt task DDL timeout and specify
how long the client application and agent should wait synchronously
before returning with tasks left running in the background.

The usecase for this is running bolt tasks from a CI system, and
having the mco task run command block until the task is done
(provided a suitable timeout is set).

Works so far:
- lowering the timeout below the default of 60s

Not done yet:
- Support for increasing the timeout beyond the default 60s
- Determining whether this should be a separate parameter, or
  whether the mco rpc `timeout` parameter should be passed through
  instead
- Tests
- Docs